### PR TITLE
Invert load-order

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ dms-kinesis-gen
 
 # Pattern on filenames
 
-All the files inside the folder should follow the following pattern
+All the files inside the folder should follow the following pattern.
 
 ```bash
 loadOrder.schema.table.json
@@ -64,6 +64,15 @@ loadOrder.schema.table.json
 For example
 
 ```bash
+1.OT.CUSTOMER.json
+2.OT.PRODUCTS.json
+```
+
+The bigger the load-order, first it will be loaded, following the same patter from [Amazon DMS Docs](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Tasks.CustomizingTasks.TableMapping.SelectionTransformation.Selections.html).
+
+For the example files, the order will be:
+```bash
+2.OT.PRODUCTS.json
 1.OT.CUSTOMER.json
 ```
 
@@ -100,7 +109,7 @@ This JSON file will generate the following Kinesis Record
 # Prompts
 
 ```bash
-√ What's the folder where the JSON files are located ? ... files
+√ What's the folder where the JSON files are located ? ... C:\Users\my-user\Documents\cdc-files
 √ What's the name of the kinesis stream? ... my-localstack-stream
 √ What's the partition key? ... 1
 √ What's the localstack endpoint? ... http://localhost:4566

--- a/src/core/usecase/generateKinesisEvents.spec.ts
+++ b/src/core/usecase/generateKinesisEvents.spec.ts
@@ -72,7 +72,7 @@ describe("generateKinesisEvents", () => {
 
     it("throws error if filename is incorrect", async () => {
         //Given
-        const {sut, fileSystem, shell, mockJsonContent, mockDirContent} = makeSut()
+        const {sut, fileSystem} = makeSut()
         const expected = {
             partitionKey: "1",
             operation: "load",

--- a/src/core/usecase/generateKinesisEvents.ts
+++ b/src/core/usecase/generateKinesisEvents.ts
@@ -45,7 +45,7 @@ export class GenerateKinesisEvents implements UseCase<GenerateKinesisEventsInput
         const loadedFiles = filesToLoad.map(filepath => {
             const fileParts = filepath.split(".")
             if (fileParts.length < 4) {
-                throw new Error(`Invalid file name ${filepath}. Files should follow the pattern schema.table.json`)
+                throw new Error(`Invalid file name ${filepath}. Files should follow the pattern order.schema.table.json`)
             }
             return {
                 content: this.fileSystem.readJsonFile(`${recordFileDir}/${filepath}`),
@@ -53,9 +53,9 @@ export class GenerateKinesisEvents implements UseCase<GenerateKinesisEventsInput
                 schema: fileParts[1],
                 table: fileParts[2],
             }
-        }).sort((a, b) => a.order - b.order)
+        }).sort((a, b) => b.order - a.order)
 
-        console.log(`Running on the following order:\n ${loadedFiles.map(entry => `${entry.order}-${entry.schema}-${entry.table}`).join("\n")}`)
+        console.log(`Running on the following order:\n${loadedFiles.map(entry => `${entry.order}-${entry.schema}-${entry.table}`).join("\n")}`)
         for (const loadedFile of loadedFiles) {
             const content = Array.isArray(loadedFile.content) ? loadedFile.content : [loadedFile.content]
             const instructions = content.map(


### PR DESCRIPTION
PR to Issue: https://github.com/sonikro/kinesis-dms-record-generator/issues/3

- Adjusting load-order to be from bigger order to lower order.
- Implemented unit tests for these cases.
- Adjusted typos in tests and removed unused variables.