### PR TITLE
Fix/cli batch size parameter

### DIFF
--- a/src/core/usecase/GenerateKinesisEvents/GenerateKinesisEvents.ts
+++ b/src/core/usecase/GenerateKinesisEvents/GenerateKinesisEvents.ts
@@ -51,25 +51,25 @@ export class GenerateKinesisEvents
           operation,
         }),
       );
-      const totalBatchs = Math.ceil(payloads.length / input.batchSize);
+      const totalBatches = Math.ceil(payloads.length / input.batchSize);
       const batchProgressBar = this.progressBar.createSingleBar({
-        total: totalBatchs,
+        total: totalBatches,
         startValue: 0,
         payload: {
           fileName: file.filename,
-          dataType: 'Batchs',
+          dataType: 'Batch(es)',
         },
       });
 
       let sliceInitialIndex = 0;
-      for (let i = 0; i < totalBatchs; i++) {
-        const payloadBatchs = payloads.slice(
+      for (let i = 0; i < totalBatches; i++) {
+        const payloadBatches = payloads.slice(
           sliceInitialIndex,
           sliceInitialIndex + input.batchSize,
         );
         sliceInitialIndex += input.batchSize;
-        await this.kinesisClient.send(payloadBatchs);
-        loadedRecords += payloadBatchs.length;
+        await this.kinesisClient.send(payloadBatches);
+        loadedRecords += payloadBatches.length;
         batchProgressBar.increment();
       }
       totalProgressBar.increment();

--- a/src/entrypoints/cli.ts
+++ b/src/entrypoints/cli.ts
@@ -20,7 +20,7 @@ import { NodeProgressBar } from '../providers/NodeProgressBar';
       'load',
     )
     .option(
-      '-c, --batch-size <value>',
+      '-b, --batch-size <value>',
       'batch-size for batch processing (1 to 500)',
       GenerateKinesisEvents.validateBatchSize,
       '1',

--- a/src/entrypoints/cli.ts
+++ b/src/entrypoints/cli.ts
@@ -45,7 +45,7 @@ import { NodeProgressBar } from '../providers/NodeProgressBar';
       partitionKey: response.partitionKey,
       localstackEndpoint: response.localstackEndpoint,
       operation: response.operation,
-      batchSize: response.batchSize,
+      batchSize: +response.batchSize,
     });
     console.info(usecaseResponse);
   } catch (err: any) {


### PR DESCRIPTION
cli
- Fix parameter name on CLI for batch size. It was requiring as `-c` instead of `-b` 
- Ensure the batchSize is sent as number, by adding a `+`, because by default, the commander lib send it as `any`. And this can cause the following error:
![image](https://user-images.githubusercontent.com/67848049/172468620-7fcace58-7778-4e39-8d65-91bb86801297.png)


Use case:
- rename variable from `payloadBatchs` to `payloadBatches`

Tests:
- Add a new test case
- Fix test without assertion
- Check calls when running in specific order
- Check use case return